### PR TITLE
Fix aga bplcon0 bpu3

### DIFF
--- a/src/ace/utils/extview.c
+++ b/src/ace/utils/extview.c
@@ -278,7 +278,10 @@ void viewLoad(tView *pView)
 		// Seems strange that everything relies on the first viewport flags, and palette etc
 #ifdef ACE_USE_AGA_FEATURES
 		if (pView->pFirstVPort->eFlags & VP_FLAG_AGA) {
-			g_pCustom->bplcon0 = ((0x07 & pView->pFirstVPort->ubBpp) << 12) | BV(9) | BV(4); // BPP + composite output
+			g_pCustom->bplcon0 = ((0x07 & pView->pFirstVPort->ubBpp) << 12) | BV(9); // BPP + composite output
+			if (pView->pFirstVPort->ubBpp & 0x08) {
+				g_pCustom->bplcon0 |= BV(4);
+			}
 			if ( pView->pFirstVPort->ubBpp == 6) {
 			
 				g_pCustom->bplcon2 = BV(9);  // Set KillEHB flag, since we have declared out viewport to be aga, and 64 colours.


### PR DESCRIPTION
## Summary

Fix AGA `BPLCON0` bitplane count setup for viewports below 8 BPP.

Previously, the AGA path in `viewLoad()` always set `BPU3` (`BV(4)`) in `BPLCON0`. This makes hardware interpret the viewport as using an 8-bitplane mode even when the requested viewport depth is lower, e.g. 5 BPP. In practice this can result in a blank screen while the rest of the program continues running.

This change sets `BPU3` only when the requested bitplane count actually needs it.

## Details

- Preserve the existing lower 3-bit BPP setup via `(ubBpp & 0x07) << 12`.
- Set `BPU3` only when `ubBpp & 0x08` is true.
- This keeps AGA viewport setup correct for both lower depths (`1-7 BPP`) and `8 BPP`.

## Test

Tested with an AGA-enabled ACE project using a 5 BPP viewport on an A1200 FS-UAE configuration. Before the fix, palette updates and game logic worked, but bitmap/sprite output was blank. After the fix, graphics and sprites render correctly.