### PR TITLE
Fix fmode 1 and 2

### DIFF
--- a/src/ace/managers/viewport/simplebuffer.c
+++ b/src/ace/managers/viewport/simplebuffer.c
@@ -32,6 +32,23 @@ static void updateBitplanePtrs(
 	}
 }
 
+#ifdef ACE_USE_AGA_FEATURES
+static UWORD simpleBufferGetDDFStep(const tSimpleBufferManager *pManager) {
+	UWORD uwWidth = pManager->sCommon.pVPort->pView->uwWidth;
+	UBYTE ubBitplaneFmode = pManager->sCommon.pVPort->ubFmode & 0x03;
+
+	if(ubBitplaneFmode == 1 || ubBitplaneFmode == 2) {
+		return ((uwWidth / 32) - 1) * 16;
+	}
+
+	if(ubBitplaneFmode == 3) {
+		return ((uwWidth / 16) - 1) * 6;
+	}
+
+	return ((uwWidth / 16) - 1) * 8;
+}
+#endif
+
 static void simpleBufferInitializeCopperList(
 	tSimpleBufferManager *pManager, UBYTE isScrollX
 ) {
@@ -44,10 +61,7 @@ static void simpleBufferInitializeCopperList(
 	
 	UWORD uwDDFStep = ((pManager->sCommon.pVPort->pView->uwWidth / 16)-1)*8;
 #ifdef ACE_USE_AGA_FEATURES
-	if (pManager->sCommon.pVPort->ubFmode == 3)
-	{
-		uwDDFStep = ((pManager->sCommon.pVPort->pView->uwWidth / 16)-1)*6;
-	}
+	uwDDFStep = simpleBufferGetDDFStep(pManager);
 #endif
 	UWORD uwDDfStop = uwDDfStrt + uwDDFStep;
 	if(pManager->sCommon.pVPort->eFlags & VP_FLAG_HIRES) {
@@ -67,8 +81,17 @@ static void simpleBufferInitializeCopperList(
 			uwModulo -= 4;
 		}
 		else {
-			uwDDfStrt -= 8; // one more lores 8-part bitplane fetch pattern: x351x240
-			uwModulo -= 2;
+#ifdef ACE_USE_AGA_FEATURES
+			if((pManager->sCommon.pVPort->ubFmode & 0x03) == 1 || (pManager->sCommon.pVPort->ubFmode & 0x03) == 2) {
+				uwDDfStrt -= 16;
+				uwModulo -= 4;
+			}
+			else
+#endif
+			{
+				uwDDfStrt -= 8; // one more lores 8-part bitplane fetch pattern: x351x240
+				uwModulo -= 2;
+			}
 		}
 	}
 	logWrite("DDFSTRT: %04X, DDFSTOP: %04X, Modulo: %u\n", uwDDfStrt, uwDDfStop, uwModulo);
@@ -80,7 +103,15 @@ static void simpleBufferInitializeCopperList(
 			ulBplOffs = -4;
 		}
 		else {
-			ulBplOffs = -2;
+#ifdef ACE_USE_AGA_FEATURES
+			if((pManager->sCommon.pVPort->ubFmode & 0x03) == 1 || (pManager->sCommon.pVPort->ubFmode & 0x03) == 2) {
+				ulBplOffs = -4;
+			}
+			else
+#endif
+			{
+				ulBplOffs = -2;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Add proper AGA `FMODE=1/2` data fetch setup for `simplebuffer`.

## Details

Previously, `simplebuffer` only special-cased `FMODE=3`, while `FMODE=1` and `FMODE=2` still used the default ECS/OCS-style data fetch window. On AGA, `FMODE=1/2` use 32-bit bitplane fetches, so the data fetch stop position and scroll compensation need to differ from `FMODE=0`.

This change:

- Adds `FMODE=1/2` handling when calculating `DDFSTOP`.
- Uses the 32-bit fetch window for `FMODE=1/2`, e.g. 320px lowres now resolves to `DDFSTOP=$00c8` instead of `$00d0`.
- Adjusts the extra fetch, modulo, and bitplane offset used by X-scrolled `simplebuffer` displays from 2-byte to 4-byte units.
- Preserves the existing `FMODE=0` and `FMODE=3` behavior.

## Test

Tested with an AGA-enabled ACE project using a 320px lowres `simplebuffer` viewport in `FMODE=1`.

Before the fix, the display was visibly skewed/blurred with diagonal line offsets. After the fix, the title/menu screen renders correctly.

## Before

<img width="961" height="714" alt="Screenshot 2026-04-26 at 23 17 55" src="https://github.com/user-attachments/assets/74abddb9-b9ff-4971-9b5a-f2d174d99d6a" />

## After

<img width="1106" height="854" alt="Screenshot 2026-04-26 at 23 23 37" src="https://github.com/user-attachments/assets/51b26cdb-d958-4af2-a2c7-85187db47b1a" />
